### PR TITLE
call stopLoading when custom scheme is loaded

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -92,8 +92,8 @@ class MainApp extends StatelessWidget {
             },
             // 안드로이드에서 intent:// URL로 이동 시 오류가 아닌 빈 페이지 표시
             onLoadResourceWithCustomScheme: (controller, resource) async {
-              return CustomSchemeResponse(
-                  contentType: "text/html", data: Uint8List(0));
+              await controller.stopLoading();
+              return null;
             },
             shouldOverrideUrlLoading: (controller, navigateAction) async {
               final uri = navigateAction.request.url!.rawValue;


### PR DESCRIPTION
정확히는 모르겠지만 intent URL을 통해 외부 앱으로 이동할 경우, 웹뷰 측에서 controller.stopLoading을 호출해주어야 이후에 결제 완료 리다이렉트를 잘 받을 수 있는 것 같습니다. 이렇게 코드를 고치고나면 KB 결제도 정상적으로 진행됩니다.